### PR TITLE
Add px-app-route

### DIFF
--- a/px-app-route/README.md
+++ b/px-app-route/README.md
@@ -1,0 +1,9 @@
+#px-app-route
+
+## Overview
+
+The px-app-route component supports easy binding between various Predix UI components and a web app's URL.
+
+## Usage
+
+See the [documentation on the Predix Design System website](https://www.predix-ui.com/#/components/px-app-route/) for more information about using this component.

--- a/px-app-route/demo/index.html
+++ b/px-app-route/demo/index.html
@@ -1,0 +1,37 @@
+<!-- Common imports -->
+<link rel="import" href="../../../polymer/polymer.html" />
+
+<!-- Common demo imports -->
+<link rel="import" href="../../../px-demo/px-demo-header.html" />
+<link rel="import" href="../../../px-demo/px-demo-api-viewer.html" />
+<link rel="import" href="../../../px-demo/px-demo-footer.html" />
+
+<!-- Imports for this componnent -->
+<link rel="import" href="../../../px-demo/css/px-demo-styles.html" />
+<link rel="import" href="../px-app-route.html" />
+
+<!-- Demo DOM module -->
+<dom-module id="local-element-demo">
+  <template>
+    <style include="px-demo-styles"></style>
+
+    <!-- Header -->
+    <px-demo-header
+        module-name="px-app-route"
+        description="The px-app-route component supports easy binding between various Predix UI components and a web app's URL"
+        parent-name="px-app-helpers"
+        hide-shields>
+    </px-demo-header>
+
+    <!-- API Viewer -->
+    <px-demo-api-viewer source="px-app-route"></px-demo-api-viewer>
+
+    <!-- Footer -->
+    <px-demo-footer></px-demo-footer>
+  </template>
+</dom-module>
+<script>
+  Polymer({
+    is: 'local-element-demo'
+  });
+</script>

--- a/px-app-route/index.html
+++ b/px-app-route/index.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Predix UI</title>
+
+    <!--
+      Fast bootstrapping of the webcomponents-lite library. Only loads the library
+      if the browser doesn't natively support web components.
+    -->
+    <script type="text/javascript">
+    (function() {
+      'use strict';
+
+      var onload = function() {
+        // For native Imports, manually fire WebComponentsReady so user code
+        // can use the same code path for native and polyfill'd imports.
+        if (!window.HTMLImports) {
+          document.dispatchEvent(
+            new CustomEvent('WebComponentsReady', {bubbles: true})
+          );
+        }
+      };
+
+      var webComponentsSupported = (
+        'registerElement' in document && 'import' in document.createElement('link') && 'content' in document.createElement('template')
+      );
+
+      if (!webComponentsSupported) {
+        var script = document.createElement('script');
+        script.async = true;
+        script.src = '../../webcomponentsjs/webcomponents-lite.min.js';
+        script.onload = onload;
+        document.head.appendChild(script);
+      } else {
+        onload();
+      }
+    })();
+    </script>
+
+    <!--
+      Load the Polymer library.
+    -->
+    <link rel="import" href="../../polymer/polymer.html" />
+
+    <!--
+      Load the light theme (default theme).
+    -->
+    <link rel="import" href="../../px-theme/px-theme-styles.html">
+    <style include="px-theme-styles" is="custom-style"></style>
+
+    <!--
+      Asynchronously import the px-catalog element, which is the entrypoint
+      for our application.
+    -->
+    <link
+        async
+        id="main-element-import"
+        rel="import"
+        href="demo/index.html">
+
+    <!--
+      Load the app icon and manifest for Android devices.
+    -->
+    <link defer rel="icon" href="../favicon.ico" type="image/x-icon" />
+
+    <!--
+      Basic page styles.
+    -->
+    <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+  </head>
+
+  <body>
+    <!-- Elements wait on the page and are upgraded after demo/index.html is loaded. -->
+    <local-element-demo></local-element-demo>
+
+    <!--
+      Attempt to register a service worker with the correct scope. Fail quietly
+      if this doesn't work, but log the result to the console.
+    -->
+    <script type="text/javascript">
+      // if ('serviceWorker' in navigator) {
+      //   navigator.serviceWorker.register('service-worker.js').then(function(registration) {
+      //     // Registration was successful
+      //     console.log('ServiceWorker registration successful with scope: ', registration.scope);
+      //   }).catch(function(err) {
+      //     // registration failed :(
+      //     console.log('ServiceWorker registration failed: ', err);
+      //   });
+      // }
+    </script>
+  </body>
+</html>

--- a/px-app-route/px-app-route-helpers.html
+++ b/px-app-route/px-app-route-helpers.html
@@ -1,0 +1,1 @@
+<script src="px-app-route-helpers.js"></script>

--- a/px-app-route/px-app-route-helpers.js
+++ b/px-app-route/px-app-route-helpers.js
@@ -1,0 +1,113 @@
+(function() {
+  var PxAppRouteHelpers = {
+    isDeepEqual: function(a1, a2) {
+      if (!Array.isArray(a1) || !Array.isArray(a2)) return false;
+      if (a1.length !== a2.length) return false;
+
+      for (let i=0; i<a1.length; i++) {
+        if (a1[i] !== a2[i]) {
+          return false;
+        }
+      }
+      return true;
+    },
+
+    encodeAllPaths: function(routes, options) {
+      if (typeof routes !== 'object') return;
+
+      options = options || {};
+      var pathSegment = options.segmentPathsWith || '/';
+      var modelSegment = options.segmentModelsWith || '~';
+      var prefixFirstPath = typeof options.prefixFirstPath === 'boolean' ? options.prefixFirstPath : true;
+      var path = '';
+
+      if (Array.isArray(routes.navRoute) && routes.navRoute.length > 0) {
+        path += this.encodePath(routes.navRoute, pathSegment, prefixFirstPath);
+      }
+      if (Array.isArray(routes.assetRoute) && routes.assetRoute.length > 0) {
+        var assetPath = this.encodePath(routes.assetRoute, pathSegment, prefixFirstPath);
+        if (assetPath.length > 0) {
+          path += modelSegment + assetPath;
+        }
+      }
+
+      return path;
+    },
+
+    encodePath: function(route, segmentWith, prefixFirstPath) {
+      if (route && Array.isArray(route) && route.length > 0) {
+        var path = route.join(segmentWith);
+        return prefixFirstPath ? segmentWith + path : path;
+      }
+      return '';
+    },
+
+    decodePath: function(path, options) {
+      options = options || {};
+      var opts = {
+        navRoute: options.hasOwnProperty('navRoute') ?
+          options.navRoute : false,
+        assetRoute: options.hasOwnProperty('assetRoute') ?
+          options.assetRoute : false,
+        stripPrefix: options.hasOwnProperty('stripPrefix') ?
+          options.stripPrefix : true,
+        segmentPathsWith: options.segmentPathsWith || '/',
+        segmentModelsWith: options.segmentModelsWith || '~'
+      };
+
+      return PxAppRouteHelpers._decodePath(path, opts.navRoute, opts.assetRoute, opts.stripPrefix, opts.segmentPathsWith, opts.segmentModelsWith);
+    },
+
+    _decodePath: function(path, updateNavRoute, updateAssetRoute, stripPrefix, segmentPathsWith, segmentModelsWith) {
+      if (typeof path !== 'string' || !path.length) {
+        return undefined;
+      }
+
+      var nav;
+      var asset;
+      var decoded = {};
+
+      if (updateNavRoute && updateAssetRoute) {
+        // If the `segmentModelsWith` character isn't present, we'll only
+        // decode the nav route
+        if (path.indexOf(segmentModelsWith) === -1) {
+          nav = path;
+        }
+        else {
+          nav = path.split(segmentModelsWith)[0];
+          asset = path.split(segmentModelsWith)[1];
+        }
+      }
+      else if (updateNavRoute) {
+        nav = path;
+      }
+      else if (updateAssetRoute) {
+        asset = path;
+      }
+
+      // Slice off preceding `/` or developer-defined segment character
+      if (typeof nav === 'string' && stripPrefix && nav[0] === segmentPathsWith) {
+        nav = nav.slice(1);
+      }
+      if (typeof asset === 'string' && stripPrefix && asset[0] === segmentPathsWith) {
+        asset = asset.slice(1);
+      }
+
+      if (typeof nav === 'string' && nav.length > 0) {
+        decoded.navRoute = nav.split(segmentPathsWith);
+      }
+      if (typeof asset === 'string' && asset.length > 0) {
+        decoded.assetRoute = asset.split(segmentPathsWith);
+      }
+
+      return decoded;
+    }
+  };
+
+  if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
+    module.exports = PxAppRouteHelpers;
+  } else {
+    window.PxApp = (window.PxApp || {});
+    window.PxApp.RouteHelpers = (window.PxApp.RouteHelpers || PxAppRouteHelpers);
+  }
+})();

--- a/px-app-route/px-app-route.html
+++ b/px-app-route/px-app-route.html
@@ -1,0 +1,621 @@
+<link rel="import" href="../../polymer/polymer.html"/>
+<link rel="import" href="px-app-route-helpers.html"/>
+
+<!--
+`px-app-route` supports easy binding between various Predix UI components and
+a web app's URL. It helps keep UI state in sync with the URL, allowing users
+to bookmark or share views by copying the current URL state.
+
+`px-app-route` relies on the Polymer team's [`app-location`](https://www.webcomponents.org/element/PolymerElements/app-route)
+element to manage the window location and history state. The element will consume
+the `route` provided by `app-location` and send updates to other components
+on the page when the URL changes. Interaction with other components on the page
+will be propagated up to the URL using the same bindings.
+
+### Installing and including in an app
+
+The `px-app-route` element is included as part of the `px-app-helpers` package.
+To install the element using bower, use the following command:
+
+    bower install --save px-app-helpers
+
+After installing, import the code using HTML imports into the app file that
+implements `px-app-helpers`. You'll also need to import `app-location` from the
+Polymer team's `app-route` package.
+
+    <link rel="import" href="/bower_components/app-route/app-location.html"/>
+    <link rel="import" href="/bower_components/px-app-helpers/px-app-route/px-app-route.html"/>
+
+The `app-route` package will be installed automatically when `px-app-helpers`
+is included in your bower file.
+
+### Using px-app-route
+
+The following simplified example shows how `px-app-route` can be used to send
+updates to the [`px-app-nav`](https://www.predix-ui.com/#/components/px-app-nav/)
+element when the URL changes, and update the URL when the navigation is
+interacted with:
+
+    <app-location route="{{route}}" use-hash-as-path></app-location>
+    <px-app-route
+        route="{{route}}"
+        use-hash-as-path
+        update-nav-route
+        nav-route="{{navRoute}}">
+    </px-app-route>
+    <px-app-nav
+        items="{{navItems}}"
+        selected-route="{{navRoute}}">
+    </px-app-nav>
+
+If the following `navItems` are defined:
+
+    [
+      {
+        "id" : "home",
+        "label" : "Home"
+      },
+      {
+        "id" : "dashboards",
+        "label" : "Dashboards",
+        "children" : [
+          {
+            "id" : "a1",
+            "label" : "Alerts"
+          }
+        ]
+      }
+    ]
+
+Then tapping on the 'Alerts' navigation button will change the URL to
+"https://example.com/#/dashboards/alerts". Bookmarking that URL and loading
+it again later will automatically select the 'Alerts' navigation item
+on page load.
+
+### Complex routing: navigation and assets
+
+Many complex applications require the user the navigate to a view (like the
+'Alerts' dashboard view in the example above) and provide some additional
+information about the kind of asset or context they would like to view.
+The [`px-context-browser`](https://www.predix-ui.com/#/components/px-context-browser/)
+and [`px-breadcrumbs`](https://www.predix-ui.com/#/components/px-breadcrumbs/)
+elements both help the user select the specific asset they would like to view.
+
+The `px-app-route` element supports binding to the navigation to allow users to
+navigate to purpose-driven views, and binding to multiple asset browsing elements
+to update whats visible within the view.
+
+The following example shows all of these elements working together:
+
+    <app-location route="{{route}}" use-hash-as-path></app-location>
+    <px-app-route
+        route="{{route}}"
+        use-hash-as-path
+        update-nav-route
+        nav-route="{{navRoute}}">
+    </px-app-route>
+    <px-app-nav
+        items="{{navItems}}"
+        selected-route="{{navRoute}}">
+    </px-app-nav>
+    <px-context-browser
+        items="{{assetItems}}"
+        selected-route="{{assetRoute}}">
+    </px-context-browser>
+    <px-breadcrumbs
+        items="{{assetItems}}"
+        selected-route="{{assetRoute}}">
+    </px-breadcrumbs>
+
+If the following `navItems` are defined:
+
+    [
+      {
+        "id" : "home",
+        "label" : "Home"
+      },
+      {
+        "id" : "dashboards",
+        "label" : "Dashboards",
+        "children" : [
+          {
+            "id" : "a1",
+            "label" : "Alerts"
+          }
+        ]
+      }
+    ]
+
+And the following `assetItems` are defined:
+
+    [
+      {
+        "id" : "us",
+        "label" : "United States",
+        "children" : [
+          {
+            "id" : "calif",
+            "label" : "California",
+            "children" : [
+              {
+                "id" : "bay-area",
+                "label" : "San Francisco Bay Area"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+
+If the user selects the 'Alerts' view and uses the context browser to choose
+'San Francisco Bay Area' as a filter for the visible alerts, the URL will
+be changed to the following: "https://example.com/#/dashboards/alerts~/us/calif/bay-area"
+
+### Changing the way URLs are built
+
+The URL path produced by `px-app-route` can be bound to two models: the navigation
+model (through `navRoute`) and the asset model (through `assetRoute`). Depending
+on the needs of the web app, one or both models can be bound to.
+
+The selected item in each model can be represented as:
+
+  - a **route**, an array of unique ID strings that start at the root of the model
+  graph and terminate at the selected item (e.g. `["us", "calif", "bay-area"]`).
+  - a **path**, a stringified representation of the route that can be used to
+  set the URL path (e.g. "us/calif/bay-area")
+
+By default, the route segments are joined together with the '/' character, but
+that can be changed:
+
+    <app-location route="{{route}}" use-hash-as-path></app-location>
+    <px-app-route
+        route="{{route}}"
+        use-hash-as-path
+        update-nav-route
+        nav-route="{{navRoute}}"
+        segment-paths-with=".">
+    </px-app-route>
+
+In the above example, the navigation model route `["us", "calif", "bay-area"]`
+would be transformed into the path string "us.calif.bay-area".
+
+Choose a safe, unreserved URI character to ensure there are no issues setting
+URL path or loading it later. See [RFC 3986](http://www.ietf.org/rfc/rfc3986.txt)
+for a list of unsafe and reserved characters. In general, use one of: `-`, `.`,
+`_`, or `~`. The chosen character should not appear in any of the unique ID
+strings in the model route.
+
+When two models are used, the models must be joined together with a character
+to divide the two paths. By default, the models are joined with the '~'
+character. Set the `segment-models-with` attribute on the `px-app-route` element
+to a safe, unreserved URI character to change this.
+
+### Routing with hash
+
+When the backend application server is not setup to manage routes and send frontend
+routes to a single-page web app index file the hash portion of the URL can be
+used to do routing. To enable hash-based URLs, enable the `use-hash-as-path`
+attribute on both the `px-app-route` element and the `app-location` element that
+produces the route.
+
+### Integrating px-app-route with other routers
+
+The `encodeAllPaths`, `encodePath`, and `decodePath` methods available on all
+`px-app-route` instances can also be called directly without stamping a
+`px-app-route` element in your app.
+
+Those methods are available at `window.PxApp.RouteHelpers.[METHOD_NAME]`.
+Calling these methods directly on the window is a useful way to encode and
+decode model routes on your page and send the result to a third-party router
+(e.g. any Angular or React router).
+
+See the API documentation for this component for more information on how
+to use the static methods to encode and decode model routes/paths.
+
+@element px-app-route
+-->
+<script>
+  (function() {
+    Polymer({
+      is: 'px-app-route',
+
+      properties: {
+        /**
+         * Valid URI-safe character used to seperate URL path segments. Defaults
+         * to '/' (e.g. the path ['about','company-info'] would be joined as
+         * 'about/company-info').
+         *
+         * Choose a safe, unreserved URI character to ensure there are no issues.
+         * See [RFC 3986](http://www.ietf.org/rfc/rfc3986.txt) for a list of
+         * unsafe and reserved characters. In general, use one of: `-`, `.`,
+         * `_`, or `~`. Note that character should not occur in any paths.
+         */
+        segmentPathsWith: {
+          type: String,
+          value: '/'
+        },
+
+        /**
+         * Valid URI-safe character used to seperate different models in the
+         * URL. Defaults to '~' (e.g. the nav path ['about','company-info'] and
+         * asset path ['dashboards','trucks'] would be joined as
+         * 'about/company-info~dashboards/trucks'.
+         *
+         * Choose a safe, unreserved URI character to ensure there are no issues.
+         * See [RFC 3986](http://www.ietf.org/rfc/rfc3986.txt) for a list of
+         * unsafe and reserved characters. In general, use one of: `-`, `.`,
+         * `_`, or `~`. Note that character should not occur in any paths.
+         */
+        segmentModelsWith: {
+          type: String,
+          value: '~'
+        },
+
+        /**
+         * Bind this property to the `route` exposes by the <app-location> element.
+         * Updates to the URL path will be propagated to `route.path` and decoded
+         * by this component to update the app-nav and app-asset models. Updates
+         * to the models will be pushed to the URL path.
+         */
+        route: {
+          type: Object,
+          notify: true,
+          observer: '_handleRouteChanged'
+        },
+
+        /**
+         * Set to `true` if the URL path will be prefixed with a `#` character.
+         * This should also be enabled on the <app-location> element that shares
+         * its route with this component.
+         */
+        useHashAsPath: {
+          type: Boolean,
+          value: false
+        },
+
+        /**
+         * Set to `true` to sync a <px-app-nav> component's state with the URL
+         * bar. See the `navRoute` property for help on binding changes.
+         */
+        updateNavRoute: {
+          type: Boolean,
+          value: false
+        },
+
+        /**
+         * Bind this property to a <px-app-nav> component's `selectedRoute`
+         * property to keep the navigation state in sync with the URL path.
+         * Must enable `updateNavRoute` for this to work.
+         */
+        navRoute: {
+          type: Array,
+          notify: true
+        },
+
+        /**
+         * Read-only string that is computed from the `navRoute`. Will be
+         * pushed into the URL path.
+         */
+        navPathString: {
+          type: String,
+          readOnly: true,
+          value: '',
+          computed: '_computeAppNavPathString(updateNavRoute, navRoute, segmentPathsWith)'
+        },
+
+        /**
+         * Set to `true` to sync the state of components that use the Asset Graph
+         * Behavior with the URL path. See the `assetRoute` property for help
+         * on binding changes.
+         */
+        updateAssetRoute: {
+          type: Boolean,
+          value: false
+        },
+
+        /**
+         * Bind this property to a the `selectedRoute` property of one or more
+         * components that use the Asset Graph Behavior to keep the selected
+         * asset state in sync with the URL path. Must enable `updateAssetRoute` for
+         * this to work.
+         */
+        assetRoute: {
+          type: Array,
+          notify: true
+        },
+
+        /**
+         * Read-only string that is computed from the `assetRoute`. Will be
+         * pushed into the URL path.
+         */
+        assetPathString: {
+          type: String,
+          readOnly: true,
+          value: '',
+          computed: '_computeAppAssetPathString(updateAssetRoute, assetRoute, segmentPathsWith)'
+        },
+
+        /**
+         * Read-only string that is computed from the `navRoute` and
+         * `assetRoute` models (if they are enabled). Will be used to set the
+         * URL path.
+         */
+        path: {
+          type: String,
+          readOnly: true,
+          computed: '_computePath(updateNavRoute, navPathString, updateAssetRoute, assetPathString, segmentPathsWith, segmentModelsWith, useHashAsPath)',
+          observer: '_handlePathChanged'
+        },
+
+        _isReady: Boolean
+      },
+
+      observers: [
+        '_windowPathChanged(route.path)'
+      ],
+
+      ready: function() {
+        this._isReady = true;
+      },
+
+      _computeAppNavPathString: function(updateNavRoute, navRoute, segmentPathsWith) {
+        if (!updateNavRoute) return;
+
+        if (navRoute === null || (Array.isArray(navRoute) && navRoute.length === 0)) {
+          return '';
+        }
+
+        if (Array.isArray(navRoute) && navRoute.length > 0) {
+          return navRoute.join(segmentPathsWith);
+        }
+      },
+
+      _computeAppAssetPathString: function(updateAssetRoute, assetRoute, segmentPathsWith) {
+        if (!updateAssetRoute) return;
+
+        if (assetRoute === null || (Array.isArray(assetRoute) && assetRoute.length === 0)) {
+          return '';
+        }
+
+        if (Array.isArray(assetRoute) && assetRoute.length > 0) {
+          return assetRoute.join(segmentPathsWith);
+        }
+      },
+
+      _computePath: function(updateNavRoute, navPath, updateAssetRoute, assetPath, pathSegment, modelSegment, useHash) {
+        if ((!updateNavRoute && !updateAssetRoute) || (navPath === '' && assetPath === '')) return;
+
+        // If we're routing with a has, prefix with a `/` so the url looks nice
+        var path = useHash ? pathSegment : '';
+
+        if (updateNavRoute) {
+          path += navPath;
+        }
+
+        if (updateAssetRoute && assetPath.length > 0) {
+          path += modelSegment + pathSegment + assetPath;
+        }
+
+        return path;
+      },
+
+      _handlePathChanged: function(newPath, oldPath) {
+        if (!this._isReady || !this.route || typeof this.route !== 'object') return;
+
+        this.set('route.path', newPath);
+      },
+
+      _handleRouteChanged: function(newRoute, oldRoute) {
+        if (typeof newRoute === 'object' && typeof oldRoute === 'undefined' && typeof this.path === 'string') {
+          // Inside app-location, which is the source of route, there is some
+          // setup time where changes to the `route.path` won't propagate to
+          // the window location. Wait 10ms to send the initial path up.
+          this.async(this._handlePathChanged.bind(this, this.path), 10);
+        }
+      },
+
+      _windowPathChanged: function(newPath) {
+        if (!this._isReady || typeof newPath !== 'string' || !newPath.length || this.path === newPath) return;
+
+        var decoded = PxApp.RouteHelpers._decodePath(
+          newPath,
+          this.updateNavRoute,
+          this.updateAssetRoute,
+          true,
+          this.segmentPathsWith,
+          this.segmentModelsWith
+        );
+
+        if (decoded.navRoute && !this.isDeepEqual(this.navRoute, decoded.navRoute)) {
+          this.set('navRoute', decoded.navRoute);
+        }
+        if (decoded.assetRoute && !this.isDeepEqual(this.assetRoute, decoded.assetRoute)) {
+          this.set('assetRoute', decoded.assetRoute)
+        }
+      },
+
+      /**
+       * Encodes multiple route models into a path string that can be passed to
+       * a JavaScript router (or to `window.location`). Pass an object with
+       * `navRoute` and `assetRoute` route arrays and an optional configuration
+       * object.
+       *
+       * To generate a path for nav and asset items, call with the following
+       * arguments:
+       *
+       * ```
+       *   encodeAllPaths(
+       *     {
+       *       navRoute: ['dashboards', 'truck-locations'],
+       *       assetRoute: ['us', 'calif', 'bay-area']
+       *     },
+       *     {
+       *       segmentPathsWith: '/',
+       *       segmentModelsWith: '~',
+       *       prefixFirstPath: true
+       *     }
+       *   );
+       * ```
+       *
+       * The following string will be returned:
+       *
+       * ```
+       *   '/dashboards/truck-locations~/us/calif/bay-area'
+       * ```
+       *
+       * ## Passing routes
+       *
+       * The `routes` argument should be an object with one or both of the
+       * following keys:
+       *
+       *   - `navRoute`: An array of strings
+       *   - `assetRoute`: An array of strings
+       *
+       * ## Configuring the encoder
+       *
+       * The following `options` can be passed to change the output:
+       *
+       *   - `segmentPathsWith`: Any URI-safe character (one of `-`, `.`, `_`, or `~`)
+       *   - `segmentModelsWith`: Any URI-safe character (one of `-`, `.`, `_`, or `~`)
+       *   - `prefixFirstPath`: Adds the path segment character to the front of the returned path
+       *
+       * @param  {Object}  routes
+       * @param  {Object}  options
+       * @return {String}
+       */
+      encodeAllPaths(routes, options) {
+        return PxApp.RouteHelpers.encodeAllPaths(routes, options);
+      },
+
+
+      /**
+       * Encodes a route (an array of string) into a path string that can be passed
+       * to a JavaScript router (or to `window.location`). Pass an array of
+       * strings and a URI-safe character to segment the strings with (e.g. '/').
+       * Optionally set the `prefixFirstPath` argument to true to add the segment
+       * character to the front of the path.
+       *
+       * For example, given the following settings:
+       *
+       * ```
+       *   encodePath(['dashboards', 'truck-locations'], '/', true);
+       * ```
+       *
+       * The following string will be returned:
+       *
+       * ```
+       *   '/dashboards/truck-locations'
+       * ```
+       *
+       * @param  {Array}   route - an array of string
+       * @param  {Object}  segmentWith - a URI-safe character that will be placed between each path segment
+       * @param  {Boolean} prefixFirstPath - adds the segment character to the front of the returned path
+       * @return {String}
+       */
+      encodePath: function(route, segmentWith, prefixFirstPath) {
+        return PxApp.RouteHelpers.encodePath(route, segmentWith, prefixFirstPath);
+      },
+
+      /**
+       * Decodes a URI path into arrays of route strings that can be passed to
+       * other components to synchronise state.
+       *
+       * ## Decode navigation path only
+       *
+       * To decode a path string that only contains nav items, call the method
+       * with the path to decode and the following options:
+       *
+       * ```
+       *   decodePath('/dashboards/truck-locations', {
+       *     navRoute: true
+       *   });
+       * ```
+       *
+       * The following object will be returned:
+       *
+       * ```
+       *   {
+       *     navRoute: ['dashboards', 'truck-locations']
+       *   }
+       * ```
+       *
+       * ## Decode navigation and asset paths
+       *
+       * To decode a path string that contains nav items and asset items,
+       * call the method with the path to decode and the following options:
+       *
+       * ```
+       *   decodePath('/dashboards/truck-locations~/us/calif/bay-area', {
+       *     navRoute: true,
+       *     assetRoute: true
+       *   });
+       * ```
+       *
+       * The following object will be returned:
+       *
+       * ```
+       *   {
+       *     navRoute: ['dashboards', 'truck-locations'],
+       *     assetRoute: ['us', 'calif', 'bay-area']
+       *   }
+       * ```
+       *
+       * ## Configuring segment seperators
+       *
+       * The characters used to seperate segments of each path, and the character
+       * used to join multiple model paths, can be set through the options
+       * object to any URI-safe character (one of `-`, `.`, `_`, or `~`).
+       *
+       * To decode this custom path, use the following options:
+       *
+       * ```
+       *   decodePath('alerts.inbox_factories.factory1.area38', {
+       *     navRoute: true,
+       *     assetRoute: true,
+       *     segmentPathsWith: '.',
+       *     segmentModelsWith: '_'
+       *   });
+       * ```
+       *
+       * The following object will be returned:
+       *
+       * ```
+       *   {
+       *     navRoute: ['alerts', 'inbox'],
+       *     assetRoute: ['factories', 'factory1', 'area38']
+       *   }
+       * ```
+       *
+       * ## All configurations
+       *
+       * The following `options` can be passed to change the output:
+       *
+       *   - `navRoute`: A boolean, if `true` the nav route will be decoded
+       *   - `assetRoute`: A boolean, if `true` the asset route will be decoded
+       *   - `segmentPathsWith`: Any URI-safe character (one of `-`, `.`, `_`, or `~`)
+       *   - `segmentModelsWith`: Any URI-safe character (one of `-`, `.`, `_`, or `~`)
+       *   - `stripPrefix`: Strips the `segmentPathsWith` character from the front of the path, if it is found there
+       *
+       * @param  {String} path
+       * @param  {Object} options
+       * @return {Object}
+       */
+      decodePath: function(path, options) {
+        return PxApp.RouteHelpers.decodePath(path, options);
+      },
+
+      /**
+       * Determines if two arrays of strings are deeply equal - returns `true`
+       * if both arrays have the same strings in the same order. Helps perform
+       * checks on the equality of arrays of route strings.
+       *
+       * @param  {Array} a1
+       * @param  {Array} a2
+       * @return {Boolean}
+       */
+      isDeepEqual: function(a1, a2) {
+        return PxApp.RouteHelpers.isDeepEqual(a1, a2);
+      }
+    });
+  })();
+</script>


### PR DESCRIPTION
The `px-app-route` component helps developers bind their app's URL with the app state (in components like `px-app-nav`, `px-context-browser`, etc.)

The documentation in `px-app-route/px-app-route.html` is very detailed and should explain exactly how developers can use this component in coordination with other components to manage the URL state easily.

@mdwragg could you review? Thanks.